### PR TITLE
Remove NEXT_PUBLIC_DOMAIN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,3 @@
-# Url of the marketplace you created in Builder
-NEXT_PUBLIC_DOMAIN="https://{SUBDOMAIN}.sequence.market"
-
 # Environment, must be set to "next" for now
 NEXT_PUBLIC_ENV="next"
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@ To create sample file from `.env.example`
 File:
 
 ```sh
-# Url of the marketplace you created in Builder
-NEXT_PUBLIC_DOMAIN="https://{SUBDOMAIN}.sequence.market"
-
 # Environment, must be set to "next" for now
 NEXT_PUBLIC_ENV="next"
 

--- a/src/config/consts.ts
+++ b/src/config/consts.ts
@@ -29,7 +29,8 @@ const SERVICES = {
   directorySearchEndpoint:
     'https://api.sequence.build/rpc/Builder/DirectorySearchCollections',
   imageProxy: 'https://imgproxy.sequence.xyz/',
-  builderMarketplaceApi: 'https://${prefix}api.sequence.build/marketplace/',
+  builderMarketplaceApi:
+    'https://${prefix}api.sequence.build/marketplace/${projectId}',
 };
 
 export const sequenceApiURL = stringTemplate(SERVICES.sequenceApi, {});
@@ -43,7 +44,10 @@ export const marketplaceApiURL = (network: string) =>
   stringTemplate(SERVICES.marketplaceApi, { prefix, network: network });
 
 export const builderMarketplaceApi = () =>
-  stringTemplate(SERVICES.builderMarketplaceApi, { prefix });
+  stringTemplate(SERVICES.builderMarketplaceApi, {
+    prefix,
+    projectId: env.NEXT_PUBLIC_SEQUENCE_PROJECT_ID,
+  });
 
 export const rpcNodeURL = (network: string) =>
   stringTemplate(SERVICES.rpcNodeUrl, {

--- a/src/config/marketplace/index.ts
+++ b/src/config/marketplace/index.ts
@@ -1,5 +1,3 @@
-import { env } from '~/env';
-
 import { builderMarketplaceApi } from '../consts';
 import { MarketConfigSchema } from './schema';
 import { type z } from 'zod';
@@ -7,20 +5,21 @@ import { type z } from 'zod';
 export type MarketConfig = z.infer<typeof MarketConfigSchema> & {
   cssString: string;
   manifestUrl: string;
-  origin: string;
 };
 
-const domain = env.NEXT_PUBLIC_DOMAIN;
-const hostname = new URL(domain).hostname;
-const endpoint = builderMarketplaceApi() + hostname;
-
 const fetchConfig = async () => {
-  const response = await fetch(`${endpoint}/config.json`);
+  const response = await fetch(`${builderMarketplaceApi()}/config.json`);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch marketplace config: ${response.statusText}`,
+    );
+  }
+
   return MarketConfigSchema.parse(await response.json());
 };
 
 const fetchStyles = async () => {
-  const response = await fetch(`${endpoint}/styles.css`);
+  const response = await fetch(`${builderMarketplaceApi()}/styles.css`);
   const styles = await response.text();
   // React sanitizes this string, so we need to remove all quotes, they are not needed anyway
   return styles.replaceAll(/['"]/g, '');
@@ -32,7 +31,6 @@ export const getMarketConfig = async (): Promise<MarketConfig> => {
   return {
     ...config,
     cssString,
-    manifestUrl: `${endpoint}/manifest.json`,
-    origin: domain,
+    manifestUrl: `${builderMarketplaceApi()}}/manifest.json`,
   };
 };

--- a/src/config/marketplace/index.ts
+++ b/src/config/marketplace/index.ts
@@ -10,9 +10,10 @@ export type MarketConfig = z.infer<typeof MarketConfigSchema> & {
 const fetchConfig = async () => {
   const response = await fetch(`${builderMarketplaceApi()}/config.json`);
   if (!response.ok) {
-    throw new Error(
-      `Failed to fetch marketplace config: ${response.statusText}`,
-    );
+    console.error(response);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    throw new Error(`Failed to fetch marketplace config: ${response.msg}`);
   }
 
   return MarketConfigSchema.parse(await response.json());

--- a/src/env.js
+++ b/src/env.js
@@ -7,7 +7,6 @@ export const env = createEnv({
   },
 
   client: {
-    NEXT_PUBLIC_DOMAIN: z.string().url(),
     NEXT_PUBLIC_SEQUENCE_ACCESS_KEY: z.string(),
     NEXT_PUBLIC_SEQUENCE_PROJECT_ID: z.string(),
     NEXT_PUBLIC_ENV: z.enum(['dev', 'next', 'production']),
@@ -15,7 +14,6 @@ export const env = createEnv({
 
   runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,
-    NEXT_PUBLIC_DOMAIN: process.env.NEXT_PUBLIC_DOMAIN,
     NEXT_PUBLIC_SEQUENCE_ACCESS_KEY:
       process.env.NEXT_PUBLIC_SEQUENCE_ACCESS_KEY,
     NEXT_PUBLIC_SEQUENCE_PROJECT_ID:


### PR DESCRIPTION
The endpoints that required the domain name, now works with project id too. So the domain name is unnecessary
 
 Resolves: https://github.com/0xsequence/issue-tracker/issues/2875