### PR TITLE
Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+/node_modules
+/dist
+/.next
+/build
+pnpm-lock.yaml
+*.gen.*

--- a/model-viewer.d.ts
+++ b/model-viewer.d.ts
@@ -1,8 +1,8 @@
 declare namespace JSX {
   interface IntrinsicElements {
     'model-viewer': any &
-      React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>
+      React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
   }
 }
 
-declare module '@google/model-viewer'
+declare module '@google/model-viewer';

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "type": "module",
   "scripts": {
     "build": "next build",
-    "dev": "next dev -p 4420",
+    "dev": "next dev -p 4444",
     "lint": "next lint",
-    "start": "next start -p 4420",
+    "lint:fix": "next lint && prettier --write --ignore-path .prettierignore .",
+    "start": "next start -p 4444",
     "check": "tsc --noEmit",
     "knip": "knip",
     "env-file": "cp -n .env.example .env"

--- a/src/app/_providers/index.tsx
+++ b/src/app/_providers/index.tsx
@@ -10,16 +10,13 @@ import { marketConfig$ } from '~/lib/stores/marketConfig';
 
 import { ToastProvider, Tooltip } from '$ui';
 import { AccountEvents } from './accountEvents';
-import {
-  KitProvider,
-  type KitConfig,
-} from '@0xsequence/kit';
-import { KitCheckoutProvider } from '@0xsequence/kit-checkout'
+import { KitProvider, type KitConfig } from '@0xsequence/kit';
+import { KitCheckoutProvider } from '@0xsequence/kit-checkout';
 import { enableReactComponents } from '@legendapp/state/config/enableReactComponents';
+import { useMount } from '@legendapp/state/react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { WagmiProvider, type State } from 'wagmi';
-import { useMount } from '@legendapp/state/react';
 
 const queryClient = getQueryClient();
 

--- a/src/app/collection/[chainParam]/[collectionId]/_components/Sidebar/IntFilter.tsx
+++ b/src/app/collection/[chainParam]/[collectionId]/_components/Sidebar/IntFilter.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 'use client';
 
 import type { ChangeEvent } from 'react';
@@ -9,6 +8,8 @@ import { filters$ } from '../FilterStore';
 import type { FilterProps } from './PropertyFilters';
 import { observer } from '@legendapp/state/react';
 import { capitalize } from 'radash';
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
 export const IntFilter = observer(({ filter }: FilterProps) => {
   const { name, min, max } = filter;

--- a/src/app/collection/[chainParam]/[collectionId]/_components/Sidebar/IntFilter.tsx
+++ b/src/app/collection/[chainParam]/[collectionId]/_components/Sidebar/IntFilter.tsx
@@ -10,8 +10,6 @@ import type { FilterProps } from './PropertyFilters';
 import { observer } from '@legendapp/state/react';
 import { capitalize } from 'radash';
 
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-
 export const IntFilter = observer(({ filter }: FilterProps) => {
   const { name, min, max } = filter;
 

--- a/src/app/collection/[chainParam]/[collectionId]/_components/Sidebar/index.tsx
+++ b/src/app/collection/[chainParam]/[collectionId]/_components/Sidebar/index.tsx
@@ -76,7 +76,6 @@ const CollectionSidebarContent = ({
   const mode = path.includes('/sell') ? 'sell' : 'buy';
   const isBuy = mode === 'buy';
 
-
   const availableOnlyToggle = {
     id: 'available-items-only',
     checked: filters$.showAvailableOnly,

--- a/src/app/collection/[chainParam]/[collectionId]/layout.tsx
+++ b/src/app/collection/[chainParam]/[collectionId]/layout.tsx
@@ -39,10 +39,7 @@ const Layout = async ({
         />
       }
       controls={
-        <CollectionControls
-          chainId={chainId}
-          collectionId={collectionId}
-        />
+        <CollectionControls chainId={chainId} collectionId={collectionId} />
       }
       content={children}
     />

--- a/src/components/modals/Cart/type/index.tsx
+++ b/src/components/modals/Cart/type/index.tsx
@@ -3,11 +3,11 @@
 import { memo } from 'react';
 
 import { cartState } from '~/lib/stores/cart/Cart';
+import { OrderItemType } from '~/lib/stores/cart/types';
 
 import { OrderbookOrderComponents } from './orderbook';
 import { TransferOrderComponents } from './transfer';
 import { useSnapshot } from 'valtio';
-import { OrderItemType } from '~/lib/stores/cart/types';
 
 // eslint-disable-next-line react/display-name
 export const OrderRenderer = memo(() => {

--- a/src/components/ui/Button/button.tsx
+++ b/src/components/ui/Button/button.tsx
@@ -86,7 +86,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         ) : (
           <>
             {loading ? <LoadingBox /> : null}
-            {!loading ? children ?? label : null}
+            {!loading ? (children ?? label) : null}
           </>
         )}
       </Comp>

--- a/src/config/consts.ts
+++ b/src/config/consts.ts
@@ -18,7 +18,6 @@ export const DEFAULT_NETWORK = ChainId.POLYGON;
 export const SEQUENCE_MARKET_V1_ADDRESS =
   '0xB537a160472183f2150d42EB1c3DD6684A55f74c';
 
-
 const SERVICES = {
   sequenceApi: 'https://api.sequence.app',
   metadata: 'https://metadata.sequence.app',
@@ -28,8 +27,7 @@ const SERVICES = {
   directorySearchEndpoint:
     'https://api.sequence.build/rpc/Builder/DirectorySearchCollections',
   imageProxy: 'https://imgproxy.sequence.xyz/',
-  builderMarketplaceApi:
-    'https://api.sequence.build/marketplace/${projectId}',
+  builderMarketplaceApi: 'https://api.sequence.build/marketplace/${projectId}',
 };
 
 export const sequenceApiURL = stringTemplate(SERVICES.sequenceApi, {});
@@ -52,4 +50,3 @@ export const rpcNodeURL = (network: string) =>
     network: network,
     accessKey: env.NEXT_PUBLIC_SEQUENCE_ACCESS_KEY,
   });
-

--- a/src/config/networks/wagmi/index.ts
+++ b/src/config/networks/wagmi/index.ts
@@ -86,7 +86,9 @@ function getWalletConfigs(
 
   const walletObject = {
     sequence: sequenceWallet(sequenceWalletOptions),
-    ...(walletConnectId ? { walletconnect: walletConnect({ projectId: walletConnectId }) } : {}),
+    ...(walletConnectId
+      ? { walletconnect: walletConnect({ projectId: walletConnectId }) }
+      : {}),
     coinbase: coinbaseWallet({ appName: marketConfig.title }),
   } as const;
 
@@ -94,8 +96,8 @@ function getWalletConfigs(
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return supportedWallets.length
     ? // @ts-expect-error -- Missing support for Ledger
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    supportedWallets.map((key) => walletObject[key]).filter(Boolean)
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      supportedWallets.map((key) => walletObject[key]).filter(Boolean)
     : Object.values(walletObject);
 }
 

--- a/src/hooks/orderbook/useOrderbookIsValidBatch.tsx
+++ b/src/hooks/orderbook/useOrderbookIsValidBatch.tsx
@@ -1,7 +1,8 @@
-import { useQuery } from '@tanstack/react-query';
-import type { Hex } from 'viem';
 import { SEQUENCE_MARKET_V1_ADDRESS } from '~/config/consts';
 import { Orderbook } from '~/lib/sdk/orderbook/clients/Orderbook';
+
+import { useQuery } from '@tanstack/react-query';
+import type { Hex } from 'viem';
 
 export interface UseOrderbookIsValidBatchArgs {
   requestIds: bigint[];

--- a/src/hooks/transactions/useERC721Approval.ts
+++ b/src/hooks/transactions/useERC721Approval.ts
@@ -1,7 +1,7 @@
+import { ERC721 } from '~/lib/sdk/shared/clients/ERC721';
 import { BigIntReplacer } from '~/lib/utils/bigint';
 
 import { useQuery } from '@tanstack/react-query';
-import { ERC721 } from '~/lib/sdk/shared/clients/ERC721';
 
 interface Props {
   operatorAddress: string;

--- a/src/hooks/transactions/useRoyaltyPercentage.ts
+++ b/src/hooks/transactions/useRoyaltyPercentage.ts
@@ -1,9 +1,9 @@
 import { getPublicClient } from '~/config/networks/wagmi/rpcClients';
+import { EIP2981_ABI } from '~/lib/sdk/shared/abi/standard/EIP2981';
 
 import { useQuery } from '@tanstack/react-query';
 import type { Hex } from 'viem';
 import { getContract } from 'viem';
-import { EIP2981_ABI } from '~/lib/sdk/shared/abi/standard/EIP2981';
 
 interface Props {
   chainId: number;

--- a/src/hooks/ui/useElementDimensions.ts
+++ b/src/hooks/ui/useElementDimensions.ts
@@ -1,6 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
+
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { useState, useEffect, useRef } from 'react';
 

--- a/src/hooks/useCountryCode.ts
+++ b/src/hooks/useCountryCode.ts
@@ -1,18 +1,21 @@
+import { getNetworkConfig } from '~/lib/queries/clients';
+
 import { useQuery } from '@tanstack/react-query';
 
-import { getNetworkConfig } from '~/lib/queries/clients'
-
-export const useCountryCode = () => useQuery({
-  queryKey: ['useCountryCode'],
-  queryFn: async () => {
-    const config = getNetworkConfig(137)
-    const res = await fetch(`${config.sequenceApiUrl}/cdn-cgi/trace`)
-    const data = await res.text()
-    const locationIndex = data.indexOf("loc=")
-    const countryCodeIndexStart = locationIndex + 4
-    const countryCode = data.slice(countryCodeIndexStart, countryCodeIndexStart + 2)
-    return countryCode
-  },
-  staleTime: 6 * 60 * 60 * 1000,
-})
-
+export const useCountryCode = () =>
+  useQuery({
+    queryKey: ['useCountryCode'],
+    queryFn: async () => {
+      const config = getNetworkConfig(137);
+      const res = await fetch(`${config.sequenceApiUrl}/cdn-cgi/trace`);
+      const data = await res.text();
+      const locationIndex = data.indexOf('loc=');
+      const countryCodeIndexStart = locationIndex + 4;
+      const countryCode = data.slice(
+        countryCodeIndexStart,
+        countryCodeIndexStart + 2,
+      );
+      return countryCode;
+    },
+    staleTime: 6 * 60 * 60 * 1000,
+  });

--- a/src/lib/sdk/orderbook/clients/Orderbook.ts
+++ b/src/lib/sdk/orderbook/clients/Orderbook.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { getPublicClient } from '~/config/networks/wagmi/rpcClients';
 
@@ -54,7 +55,6 @@ export const getOrderbookInstance = (args: ContractInstanceParams) => {
     },
   });
 };
-
 
 export class Orderbook {
   chainId: number;

--- a/src/lib/sdk/shared/clients/ERC1155.ts
+++ b/src/lib/sdk/shared/clients/ERC1155.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { getERC1155Contract } from '../../niftyswap-v2';
 import { ERC1155_ABI } from '../abi/token/ERC1155';

--- a/src/lib/sdk/shared/clients/ERC20.ts
+++ b/src/lib/sdk/shared/clients/ERC20.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { getERC20Contract } from '../../niftyswap-v2/contracts/instances';
 import { ERC20_ABI } from '../abi/token/ERC20';

--- a/src/lib/sdk/shared/clients/ERC721.ts
+++ b/src/lib/sdk/shared/clients/ERC721.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { getERC721Contract } from '../../niftyswap-v2';
 import { ERC721_ABI } from '../abi/token/ERC721';

--- a/src/lib/utils/sardine.ts
+++ b/src/lib/utils/sardine.ts
@@ -1,12 +1,6 @@
 import { compareAddress } from '~/lib/utils/helpers';
 
-import {
-  polygon,
-  arbitrum,
-  avalanche,
-  arbitrumNova,
-  xai,
-} from 'viem/chains';
+import { polygon, arbitrum, avalanche, arbitrumNova, xai } from 'viem/chains';
 
 export const SARDINE_SUPPORTED_COUNTRIES: string[] = [
   'AL',
@@ -101,31 +95,27 @@ export const SARDINE_SUPPORTED_COUNTRIES: string[] = [
   'UY',
   'UZ',
   'VU',
-  'VN'
-]
+  'VN',
+];
 
 const SARDINE_SUPPORTED_CURRENCIES: Record<number, string[]> = {
-  [polygon.id]: [
-    '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359'
-  ],
-  [arbitrum.id]: [
-    '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'
-  ],
-  [arbitrumNova.id]: [
-    '0x750ba8b76187092b0d1e87e28daaf484d1b5273b'
-  ],
-  [avalanche.id]: [
-    '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E'
-  ],
-  [xai.id]: [
-    '0x1E3769Bd5fB2e9e9e7D4ED8667c947661F9A82E3'
-  ]
-}
+  [polygon.id]: ['0x3c499c542cef5e3811e1192ce70d8cc03d5c3359'],
+  [arbitrum.id]: ['0xaf88d065e77c8cC2239327C5EDb3A432268e5831'],
+  [arbitrumNova.id]: ['0x750ba8b76187092b0d1e87e28daaf484d1b5273b'],
+  [avalanche.id]: ['0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E'],
+  [xai.id]: ['0x1E3769Bd5fB2e9e9e7D4ED8667c947661F9A82E3'],
+};
 
-export const checkCurrencyValidity = (currencyAddress: string, chainId: number) => {
-  const supportedCurrencies = SARDINE_SUPPORTED_CURRENCIES[chainId]
-  const foundCurrency = supportedCurrencies?.find(c => compareAddress(c, currencyAddress)) 
-  return !!foundCurrency
-}
+export const checkCurrencyValidity = (
+  currencyAddress: string,
+  chainId: number,
+) => {
+  const supportedCurrencies = SARDINE_SUPPORTED_CURRENCIES[chainId];
+  const foundCurrency = supportedCurrencies?.find((c) =>
+    compareAddress(c, currencyAddress),
+  );
+  return !!foundCurrency;
+};
 
-export const checkCountryCodeValidity = (countryCode: string) => SARDINE_SUPPORTED_COUNTRIES.includes(countryCode)
+export const checkCountryCodeValidity = (countryCode: string) =>
+  SARDINE_SUPPORTED_COUNTRIES.includes(countryCode);


### PR DESCRIPTION
I also changed the port to 4444 since our public/default Oauths like google and appleid have localhost:4444 listed, but not 4420

I also made prettier ignore *.gen.* because those files include some nasty babel-related syntax that we'd need more plugins to resolve

One last strange thing, every time I run prettier it adds 
```
/* eslint-disable @typescript-eslint/no-unsafe-assignment */
```
to src/app/collection/[chainParam]/[collectionId]/_components/Sidebar/IntFilter.tsx around line 12

Something to watch out for during commits until this is fixed